### PR TITLE
plgen: a pipeline generator

### DIFF
--- a/plgen/gen.go
+++ b/plgen/gen.go
@@ -1,0 +1,432 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var rindex int = 0
+
+type PlGen struct {
+	pr          PR
+	pspecs      Spec
+	psteps      []Steps
+	plt         PipelineTask
+	pl          Pipeline
+	role        Role
+	rolebinding RoleBinding
+	plr         PipelineRun
+}
+
+type PipelineResourceParams struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+type PipelineResourceSpec struct {
+	Type   string                 `yaml:"type"`
+	Params PipelineResourceParams `yaml:"params"`
+}
+
+type Items struct {
+	APIVersion string               `yaml:"apiVersion"`
+	Kind       string               `yaml:"kind"`
+	Metadata   Metadata             `yaml:"metadata"`
+	Spec       PipelineResourceSpec `yaml:"spec"`
+}
+
+type PipelineRunResourceRef struct {
+	Name string `yaml:"name"`
+}
+
+type PipelineRunResources struct {
+	Name        string                 `yaml:"name"`
+	ResourceRef PipelineRunResourceRef `string:"resourceRef"`
+}
+
+type PipelineRunTrigger struct {
+	Type string `yaml:"type"`
+}
+
+type PipelineRunPipelineRef struct {
+	Name string `yaml:"name"`
+}
+
+type PipelineRunSpec struct {
+	ServiceAccount string                 `yaml:"serviceAccount"`
+	Timeout        string                 `yaml:"timeout"`
+	PipelineRef    PipelineRunPipelineRef `yaml:"pipelineRef"`
+	Trigger        PipelineRunTrigger     `yaml:"trigger"`
+	Resources      []PipelineRunResources `yaml:"resources,omitempty"`
+}
+
+type PipelineRun struct {
+	APIVersion string          `yaml:"apiVersion"`
+	Kind       string          `yaml:"kind"`
+	Metadata   Metadata        `yaml:"metadata"`
+	Spec       PipelineRunSpec `yaml:"spec"`
+}
+
+type Role struct {
+	APIVersion string   `yaml:"apiVersion"`
+	Kind       string   `yaml:"kind"`
+	Metadata   Metadata `yaml:"metadata"`
+}
+
+type Subjects struct {
+	Kind      string `yaml:"kind"`
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+}
+
+type RoleRef struct {
+	Kind     string `yaml:"kind"`
+	Name     string `yaml:"name"`
+	APIGroup string `yaml:"apiGroup"`
+}
+
+type RoleBinding struct {
+	APIVersion string   `yaml:"apiVersion"`
+	Kind       string   `yaml:"kind"`
+	Metadata   Metadata `yaml:"metadata"`
+	Subjects   Subjects `yaml:"subjects"`
+	RoleRef    RoleRef  `yaml:"roleRef"`
+}
+
+type Metadata struct {
+	Name string `yaml:"name"`
+}
+
+type TaskRef struct {
+	Name string `yaml:"name"`
+	Kind string `yaml:"kind"`
+}
+
+type PipelineInputs struct {
+	Name     string `yaml:"name"`
+	Resource string `yaml:"resource"`
+}
+
+type PipelineOutputs struct {
+	Name     string `yaml:"name"`
+	Resource string `yaml:"resource"`
+}
+
+type PipelineResources struct {
+	Inputs  []PipelineInputs  `yaml:"inputs,omitempty"`
+	Outputs []PipelineOutputs `yaml:"outputs,omitempty"`
+}
+
+type Tasks struct {
+	Name      string            `yaml:"name"`
+	Taskref   TaskRef           `yaml:"taskRef"`
+	Resources PipelineResources `yaml:"resources"`
+	Params    []Params          `yaml:"params,omitempty"`
+}
+
+type PR struct {
+	APIVersion string  `yaml:"apiVersion"`
+	Items      []Items `yaml:"items"`
+	Kind       string  `yaml:"kind"`
+}
+
+type Params struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"default"`
+}
+
+type Resources struct {
+	Name string `yaml:"name"`
+	Type string `yaml:"type"`
+}
+
+type Inputs struct {
+	Resources []Resources `yaml:"resources,omitempty"`
+	Params    []Params    `yaml:"params,omitempty"`
+}
+
+type Outputs struct {
+	Resources []Resources `yaml:"resources,omitempty"`
+	Params    []Params    `yaml:"params,omitempty"`
+}
+
+type Spec struct {
+	Inputs  Inputs    `yaml:"inputs"`
+	Outputs Outputs   `yaml:"outputs"`
+	Steps   []Steps   `yaml:"steps,omitempty"`
+	Volumes []Volumes `yaml:"volumes,omitempty"`
+}
+
+type Env struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+type Arg struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+type Mount struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"mountPath"`
+}
+
+type Cmd struct {
+	Command string   `yaml:"command"`
+	Args    []string `yaml:"args,omitempty"`
+}
+
+type HostPath struct {
+	Path string `yaml:"path"`
+	Type string `yaml:"type"`
+}
+
+type Volumes struct {
+	Name     string   `yaml:"name"`
+	HostPath HostPath `yaml:"hostPath"`
+}
+
+type Steps struct {
+	Name  string  `yaml:"name"`
+	Image string  `yaml:"image"`
+	Env   []Env   `yaml:"env,omitempty"`
+	Cmd   []Cmd   `yaml:"command,omitempty"`
+	Mount []Mount `yaml:"volumeMounts,omitempty"`
+	Arg   []Arg   `yaml:"arg,omitempty"`
+}
+
+type PipelineTask struct {
+	APIVersion string   `yaml:"apiVersion"`
+	Kind       string   `yaml:"kind"`
+	Meta       Metadata `yaml:"metadata"`
+	Spec       Spec     `yaml:"spec"`
+}
+
+type PipelineSpec struct {
+	Resources []Resources `yaml:"resources,omitempty"`
+	Tasks     Tasks       `yaml:"tasks"`
+}
+
+type Pipeline struct {
+	APIVersion string       `yaml:"apiVersion"`
+	Kind       string       `yaml:"kind"`
+	Meta       Metadata     `yaml:"metadata"`
+	Spec       PipelineSpec `yaml:"spec"`
+}
+
+// Marshals a GO struct into YAML definition
+// and prints a --- separator. Any error, exit
+func Marshal(in interface{}) {
+	data, err := yaml.Marshal(in)
+	if err != nil {
+		fmt.Println("Error while marshalling into yaml:", err)
+		os.Exit(1)
+	}
+	fmt.Print(string(data))
+	fmt.Println("---")
+}
+
+// Generates a Role from a USER verb
+func GenRole(plg PlGen) {
+	role := plg.role
+	Marshal(&role)
+}
+
+// Generates a RoleBinding from a USER verb
+func GenRoleBinding(plg PlGen) {
+	rolebinding := plg.rolebinding
+	Marshal(&rolebinding)
+}
+
+// Generates a pipeline, binds it with a pipeline task
+func GenPipeline(plg PlGen) {
+	pl := plg.pl
+	pl.APIVersion = apiVersion
+	pl.Kind = "Pipeline"
+	pl.Meta.Name = nomenClature + "-pipeline"
+	pl.Spec.Tasks.Name = nomenClature
+	pl.Spec.Tasks.Taskref.Name = nomenClature + "-task"
+	Marshal(&pl)
+}
+
+// Generates a pipeline run, binds it with a pipeline
+func GenPipelineRun(plg PlGen) {
+	plr := plg.plr
+	plr.APIVersion = apiVersion
+	plr.Kind = "PipelineRun"
+	plr.Metadata.Name = nomenClature + "-pipeline-run"
+	plr.Spec.Timeout = pipelineTimeout
+	plr.Spec.PipelineRef.Name = nomenClature + "-pipeline"
+	plr.Spec.Trigger.Type = pipelineTrigger
+	Marshal(&plr)
+}
+
+// Generates a pipeline task
+func GenPipelineTask(plg PlGen) {
+	plt := plg.plt
+	plt.APIVersion = apiVersion
+	plt.Kind = "Pipeline"
+	plt.Meta.Name = nomenClature + "-task"
+	Marshal(&plt)
+}
+
+// Generates a list of pipeline resources
+func GenResource(plg PlGen) {
+	pr := plg.pr
+	pr.APIVersion = "v1"
+	pr.Kind = "List"
+	Marshal(&pr)
+}
+
+// Transform a RUN step. Basically:
+// 1. Transalate any $ variables
+// 2. suffix the commands under /bin/bash
+func TransformRun(line string, step *Steps) {
+	var v []string
+	u := strings.Split(line, " ")[1:]
+	for _, old := range u {
+		if strings.HasPrefix(old, "$") {
+			v = append(v, replace(step.Arg, old))
+		} else {
+			v = append(v, old)
+		}
+	}
+	value := strings.Join(v, " ")
+	step.Cmd = append(step.Cmd, Cmd{"[\"/bin/bash\"]", []string{"-c", value}})
+	debuglog("processing RUN", u, "as", step.Cmd)
+}
+
+// Transform a USER verb.
+// Create a Cluster Role
+// Bind it with cluster-admin privilege
+func TransformRole(line string, plg *PlGen) {
+	name := strings.Split(line, " ")[1]
+	var role Role
+	var rolebinding RoleBinding
+	role.APIVersion = "v1"
+	role.Kind = "ServiceAccount"
+	role.Metadata = Metadata{Name: name}
+
+	var sub Subjects
+	sub.Kind = role.Kind
+	sub.Name = name
+	sub.Namespace = namespace
+
+	var roleref RoleRef
+	roleref.Kind = "ClusterRole"
+	roleref.Name = "cluster-admin"
+	roleref.APIGroup = "rbac.authorization.k8s.io"
+
+	rolebinding.APIVersion = "rbac.authorization.k8s.io/v1"
+	rolebinding.Kind = "ClusterRoleBinding"
+	rolebinding.Metadata.Name = rolebindingname
+	rolebinding.Subjects = sub
+	rolebinding.RoleRef = roleref
+
+	plg.plr.Spec.ServiceAccount = role.Metadata.Name
+	plg.role = role
+	plg.rolebinding = rolebinding
+	debuglog("processing USER", name, "as ClusterRoleBinding")
+}
+
+// Transform a MOUNT verb.
+// For a MOUNT A=B:
+// Create a volume with the name as _A_ and hostMount as A
+// Create a voumeMount with name as _A_ and mountPath as B
+func TransformMount(step *Steps, name string, val string, plg *PlGen) {
+	mname := strings.ReplaceAll(name, "/", "_")
+	step.Mount = append(step.Mount, Mount{Name: mname, Value: val})
+	volumes := Volumes{Name: mname, HostPath: HostPath{Path: name, Type: "unknown"}}
+	plg.pspecs.Volumes = append(plg.pspecs.Volumes, volumes)
+	debuglog("processing MOUNT", mname, "as", volumes, "and", step.Mount)
+}
+
+// Main translation loop. As we are not mandating any specific order
+// in the pipeline script, the top level PlGen object is pre-created
+// and passed to this so that as and when data elements (more import-
+// antly resources) are encountered, they can be attached to it.
+func transformSteps(plg *PlGen, stepstr string, index int) {
+	var step Steps
+	lines := strings.Split(stepstr, "\n")
+	for _, line := range lines {
+		if line != "" {
+			key := strings.Split(line, " ")[0]
+			switch key {
+			case "LABEL":
+				step.Name = strings.Split(line, " ")[1]
+				debuglog("processing LABEL", step.Name)
+			case "FROM":
+				step.Image = strings.Split(line, " ")[1]
+				debuglog("processing FROM", step.Image)
+			case "ARG", "ARGIN", "ARGOUT", "ENV", "MOUNT":
+				value := strings.Split(line, " ")[1]
+				name := strings.Split(value, "=")[0]
+				val := strings.Split(value, "=")[1]
+				if strings.HasPrefix(key, "ARG") {
+					itemName := "resource" + strconv.Itoa(rindex)
+					rindex++
+					itemType := "image"
+					if strings.HasPrefix(val, "http") {
+						itemType = "url"
+					}
+					if strings.Contains(val, "github.com") {
+						itemType = "git"
+					}
+					plg.pr.Items = append(plg.pr.Items, Items{
+						APIVersion: "tekton.dev/v1alpha1",
+						Kind:       "PipelineResource",
+						Metadata:   Metadata{Name: name},
+						Spec: PipelineResourceSpec{
+							Params: PipelineResourceParams{
+								Name:  itemName,
+								Value: val,
+							},
+							Type: itemType,
+						},
+					})
+					plg.plr.Spec.Resources = append(plg.plr.Spec.Resources, PipelineRunResources{Name: name, ResourceRef: PipelineRunResourceRef{Name: name}})
+					plg.pl.Spec.Resources = append(plg.pl.Spec.Resources, Resources{Name: name, Type: itemType})
+					if key == "ARGIN" || key == "ARG" {
+						plg.pspecs.Inputs.Resources = append(plg.pspecs.Inputs.Resources, Resources{Name: name, Type: itemType})
+						plg.pl.Spec.Tasks.Resources.Inputs = append(plg.pl.Spec.Tasks.Resources.Inputs, PipelineInputs{Name: name, Resource: itemType})
+					} else {
+						plg.pspecs.Outputs.Resources = append(plg.pspecs.Outputs.Resources, Resources{Name: name, Type: itemType})
+						plg.pl.Spec.Tasks.Resources.Outputs = append(plg.pl.Spec.Tasks.Resources.Outputs, PipelineOutputs{Name: name, Resource: itemType})
+					}
+					step.Arg = append(step.Arg, Arg{Name: name, Value: val})
+					debuglog("processing ARG", step.Arg)
+				} else if key == "ENV" {
+					step.Env = append(step.Env, Env{Name: name, Value: val})
+					debuglog("processing ENV", step.Env)
+				} else {
+					TransformMount(&step, name, val, plg)
+				}
+			case "RUN":
+				TransformRun(line, &step)
+			case "USER":
+				TransformRole(line, plg)
+			default:
+				fmt.Println("bad pipeline verb:", key)
+			}
+		}
+	}
+	plg.psteps = append(plg.psteps, step)
+}

--- a/plgen/main.go
+++ b/plgen/main.go
@@ -37,7 +37,7 @@ const (
 // a future optimization is to replace this with a proper
 // flag that receives the name of the pipeline objects
 var (
-	nomenClature = strings.ReplaceAll(os.Args[1], ".", "_")
+	nomenClature = "test"
 	debug        = false
 )
 
@@ -118,6 +118,9 @@ func main() {
 	if count == 3 {
 		debug = true
 	}
+
+	nomenClature = strings.ReplaceAll(os.Args[1], ".", "_")
+
 	// Get the file data
 	filename := os.Args[1]
 	rawdata, err := ioutil.ReadFile(filename)

--- a/plgen/main.go
+++ b/plgen/main.go
@@ -39,6 +39,7 @@ const (
 var (
 	nomenClature = "test"
 	debug        = false
+	rindex       = 0
 )
 
 // Valid verbs at the moment. When adding one, all
@@ -46,13 +47,15 @@ var (
 // for it in the switch case of transformSteps.
 var verbs = []string{"ARG", "ARGIN", "ARGOUT", "FROM", "RUN", "LABEL", "ENV", "MOUNT", "USER"}
 
-func replace(arg []Arg, variable string) string {
-	if arg == nil {
+func replace(steps *[]Steps, variable string) string {
+	if steps == nil {
 		return variable
 	}
-	for _, e := range arg {
-		if "$"+e.Name == variable {
-			return e.Value
+	for _, step := range *steps {
+		for _, e := range step.Arg {
+			if "$"+e.Name == variable {
+				return e.Value
+			}
 		}
 	}
 	return variable
@@ -125,7 +128,7 @@ func main() {
 	filename := os.Args[1]
 	rawdata, err := ioutil.ReadFile(filename)
 	if err != nil {
-		fmt.Println("error: ", err)
+		fmt.Println("error reading input file:", err)
 		os.Exit(1)
 	}
 	debuglog("reading", filename)
@@ -158,8 +161,6 @@ func main() {
 	GenRoleBinding(plg)
 	GenResource(plg)
 	GenPipeline(plg)
-	plg.pspecs.Steps = plg.psteps
-	plg.plt.Spec = plg.pspecs
 	GenPipelineTask(plg)
 	GenPipelineRun(plg)
 }

--- a/plgen/main.go
+++ b/plgen/main.go
@@ -119,7 +119,7 @@ func main() {
 		debug = true
 	}
 
-	nomenClature = strings.ReplaceAll(os.Args[1], ".", "_")
+	nomenClature = strings.ReplaceAll(os.Args[1], ".", "-")
 
 	// Get the file data
 	filename := os.Args[1]

--- a/plgen/main.go
+++ b/plgen/main.go
@@ -1,0 +1,162 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Some static assumptions used in the tool
+const (
+	apiVersion      = "tekton.dev/v1alpha1"
+	namespace       = "default"
+	pipelineTimeout = "1h0m0s"
+	pipelineTrigger = "manual"
+	rolebindingname = "admin"
+	apiGroup        = "rbac.authorization.k8s.io"
+)
+
+// Name of the pipeline, pipelinerun, pipelinetask etc.
+// are gleaned from the input file name.
+// a future optimization is to replace this with a proper
+// flag that receives the name of the pipeline objects
+var (
+	nomenClature = strings.ReplaceAll(os.Args[1], ".", "_")
+	debug        = false
+)
+
+// Valid verbs at the moment. When adding one, all
+// what you need to make sure is you have an entry
+// for it in the switch case of transformSteps.
+var verbs = []string{"ARG", "ARGIN", "ARGOUT", "FROM", "RUN", "LABEL", "ENV", "MOUNT", "USER"}
+
+func replace(arg []Arg, variable string) string {
+	if arg == nil {
+		return variable
+	}
+	for _, e := range arg {
+		if "$"+e.Name == variable {
+			return e.Value
+		}
+	}
+	return variable
+}
+
+func isValidVerb(a string) bool {
+	for _, b := range verbs {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+func validateSanity(step string, sindex int) {
+
+	// sanity #1: verbs start with LABEL
+	if !strings.HasPrefix(step, "LABEL ") {
+		fmt.Println("Pipeline steps start with LABEL verb")
+		os.Exit(1)
+	}
+
+	// sanity #2: verbs only from within a known subset
+	lines := strings.Split(step, "\n")
+	for lindex, line := range lines {
+		var verbs = strings.Split(line, " ")
+		verb := strings.TrimSpace(verbs[0])
+		if len(verb) != 0 && !isValidVerb(verb) {
+			fmt.Println("Invalid pipeline verb", verb, "in step #", sindex+1, "line #", lindex+1)
+			os.Exit(1)
+		}
+	}
+
+	// sanity #3: no empty verbs
+	for lindex, line := range lines {
+		var verbs = strings.Split(line, " ")
+		if strings.TrimSpace(verbs[0]) != "" && len(verbs) <= 1 {
+			verb := strings.TrimSpace(verbs[0])
+			fmt.Println("Verb", verb, "does not have a value in step #", sindex+1, "line #", lindex+1)
+			os.Exit(1)
+		}
+	}
+}
+func debuglog(args ...interface{}) {
+	if debug {
+		fmt.Print("[Debug] ")
+		fmt.Println(args...)
+	}
+}
+
+func main() {
+
+	// Our master pipeline db
+	var plg PlGen
+
+	// Validate proper usage
+	count := len(os.Args)
+	if count != 2 && count != 3 {
+		fmt.Println("Usage: plgen <filename> [-v]")
+		os.Exit(1)
+	}
+
+	if count == 3 {
+		debug = true
+	}
+	// Get the file data
+	filename := os.Args[1]
+	rawdata, err := ioutil.ReadFile(filename)
+	if err != nil {
+		fmt.Println("error: ", err)
+		os.Exit(1)
+	}
+	debuglog("reading", filename)
+	data := string(rawdata)
+
+	// Get the data split as steps
+	re := regexp.MustCompile("\nLABEL ")
+	steps := re.Split(data, -1)
+	for index := range steps {
+		if index > 0 {
+			steps[index] = "LABEL " + steps[index]
+		}
+	}
+
+	// Do basic sanity on the data
+	debuglog("doing basic sanity checking on the input")
+	for index, step := range steps {
+		validateSanity(step, index)
+	}
+
+	// Perform transformation with 'step' as the unit of work
+	for index, step := range steps {
+		transformSteps(&plg, step, index)
+	}
+
+	// Print the pipeline definition
+	debuglog("generating the pipeline data")
+	debuglog("---")
+	GenRole(plg)
+	GenRoleBinding(plg)
+	GenResource(plg)
+	GenPipeline(plg)
+	plg.pspecs.Steps = plg.psteps
+	plg.plt.Spec = plg.pspecs
+	GenPipelineTask(plg)
+	GenPipelineRun(plg)
+}

--- a/plgen/plgen.md
+++ b/plgen/plgen.md
@@ -1,0 +1,330 @@
+# plgen
+
+`plgen` generates tekton pipelines that you can deploy onto kubernetes cluster with minimal or zero changes.
+
+The tool provides a high level abstraction on top of the tekton pipeline semantics, hiding most of the details and the `yaml complexity` altogether. The intent is to drastically improve user experience on working with pipelines, and transforming pipelines as an integral part of kabanero's capabiity.
+
+The main attraction of `plgen` is its input syntax - which it derives from Dockerfile. While Dockerfile uses these verbs to define attributes, execution environment and a sequence of actions that lead upto generation of an image, `plgen` uses those verbs for sequencing discrete steps into a pipeline definition, with meanings of most of the verbs in-tact.
+
+Supported verbs at the moment are:
+```
+ARG
+ARGIN
+ARGOUT
+FROM
+RUN
+LABEL
+ENV
+MOUNT
+USER
+```
+
+Feel free to raise an issue / rfe in this repo, if there is need to define new verbs.
+
+Here is an example input and the generated pipeline:\s\s
+$ cat pl.txt 
+
+```Dockerfile
+LABEL targz
+FROM ubuntu
+USER kubernetes-user
+MOUNT containers=/var/lib/containers
+ARG input=http://example.com/archive.tar.gz
+ENV foo=bar
+RUN tar xzvf $input
+RUN cat source/file.txt
+```
+
+$ plgen pl.txt
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-user
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin
+subjects:
+  kind: ServiceAccount
+  name: kubernetes-user
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    name: input
+  spec:
+    type: url
+    params:
+      name: resource0
+      value: http://example.com/archive.tar.gz
+kind: List
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: pl_txt-pipeline
+spec:
+  resources:
+  - name: input
+    type: url
+  tasks:
+    name: pl_txt
+    taskRef:
+      name: pl_txt-task
+      kind: ""
+    resources:
+      inputs:
+      - name: input
+        resource: url
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: pl_txt-task
+spec:
+  inputs:
+    resources:
+    - name: input
+      type: url
+  outputs: {}
+  steps:
+  - name: targz
+    image: ubuntu
+    env:
+    - name: foo
+      value: bar
+    command:
+    - command: '["/bin/bash"]'
+      args:
+      - -c
+      - tar xzvf http://example.com/archive.tar.gz
+    - command: '["/bin/bash"]'
+      args:
+      - -c
+      - cat source/file.txt
+    volumeMounts:
+    - name: containers
+      mountPath: /var/lib/containers
+    arg:
+    - name: input
+      value: http://example.com/archive.tar.gz
+  volumes:
+  - name: containers
+    hostPath:
+      path: containers
+      type: unknown
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: pl_txt-pipeline-run
+spec:
+  serviceAccount: kubernetes-user
+  timeout: 1h0m0s
+  pipelineRef:
+    name: pl_txt-pipeline
+  trigger:
+    type: manual
+  resources:
+  - name: input
+    resourceref:
+      name: input
+---
+```
+
+
+# The Translation Specification
+
+### ARG <key=value>
+
+Alias for ARGIN
+Defines an input argument to the pipeline step as key-value pair.
+An entry for the key is made to the PipelineResource, and referred by PipelineRun and Pipeline.
+The key and values are passed as arg field to the current pipeline step.
+
+### Example:
+
+Input:
+
+`ARG input=http://example.com/archive.tar.gz`
+
+Output:
+In PipelineResource:
+```yaml
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    name: input
+  spec:
+    type: url
+    params:
+      name: resource0
+      value: http://example.com/archive.tar.gz
+```
+In Pipeline step:
+```yaml
+    arg:
+    - name: input
+      value: http://example.com/archive.tar.gz
+```
+
+Again in Pipeline step, after $ variable translation:
+```yaml
+    - command: '["/bin/bash"]'
+      args:
+      - -c
+      - tar xzvf http://example.com/archive.tar.gz
+```
+
+### ARGIN <key=value>
+
+Same as ARG <key=value> .
+
+### ARGOUT <key=value>
+Defines an output argument to the pipeline step as key-value pair.
+An entry for the key is made to the PipelineResource, and referred by PipelineRun and Pipeline.
+The key and values are passed as `arg` field to the current pipeline step.
+
+### ENV <key-value>
+
+Defines an environment variable for the container in the pipeline step.
+The key and values are passed as `env` field to the current pipeline step.
+
+### Example:
+
+Input:
+`ENV foo=bar`
+
+Output:
+In Pipeline step:
+```yaml
+    env:
+    - name: foo
+      value: bar
+```
+
+### FROM <image>
+
+Defines the container to spin up for the current pipeline step.
+The image name is passed as `image` field to the current pipeline step.
+
+### Example:
+Input:
+FROM ubuntu
+
+Output:
+In Pipeline step:
+```yaml
+  steps:
+  - name: targz
+    image: ubuntu
+```
+
+
+### LABEL <name>
+
+Defines the name of the current pipeline step. It is a mandate that each step starts with a LABEL
+The label name is passed as the `name` field to the current pipeline step.
+
+### Example:
+Input:
+`LABEL targz`
+
+Output:
+In Pipeline step:
+```yaml
+  steps:
+  - name: targz
+    image: ubuntu
+```
+
+### MOUNT <host=container>
+
+Defines the mount bindings between the host and the container in the current pipeline step.
+An entry for `volumeMounts` in the current pipeline step is created with `_host_` as the name and `container` as the `mountPath`
+An entry for the `volumes` in the pipeline is created with `_host_` as the name and `host` as the `hostPath`
+
+### Example:
+Input:
+`MOUNT containers=/var/lib/containers`
+Output:
+In Pipeline step:
+
+```yaml
+    volumeMounts:
+    - name: containers
+      mountPath: /var/lib/containers
+```
+
+Again in the Pipeline step:
+```yaml
+  volumes:
+  - name: containers
+    hostPath:
+      path: containers
+      type: unknown
+```
+
+### RUN <commands>
+
+Defines the shell command(s) that will be run in the target container.
+A /bin/bash is spawned in the target container, and the entire command string is passed to it.
+$ variable translations occur before the command is dispatched, by looking up in the resources.
+
+### Example:
+Input:
+`RUN tar xzvf $input`
+Output:
+In the Pipeline step:
+```yaml
+    command:
+    - command: '["/bin/bash"]'
+      args:
+      - -c
+      - tar xzvf http://example.com/archive.tar.gz
+```
+
+
+### USER <user>
+
+Defines a kubernetes cluster service account that will `own` the generated pipeline.
+A Role is created with the user.
+A RoleBinding is created with the user, that is bound to `cluster-admin` role.
+
+### Example:
+Input:
+`USER kubernetes-user`
+
+Output:
+In Role definition:
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-user
+```
+
+In RoleBinding:
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin
+subjects:
+  kind: ServiceAccount
+  name: kubernetes-user
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+```


### PR DESCRIPTION
`plgen` is a tekton pipeline generator from simple verbs that align to Dockerfile syntax to a reasonable extent. The objective is to provide a more abstract interface to the user, hide the complex kubernetes semantics, and thereby improve the pipeline generation experience.

Fixes: https://github.com/kabanero-io/kabanero-foundation/issues/60

A targz pipeline can be encoded as below:

```Dockerfile
LABEL targz
USER core
FROM ubuntu
ARG input=http://github.com/foo/archive.tar.gz
ENV foo=bar
RUN tar xzvf $input
RUN cat source/file.txt
```

which gets (currently) translated to:

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: core
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: admin
subjects:
- kind: ServiceAccount
  name: core
  namespace: default
roleRef:
  kind: ClusterRole
  name: cluster-admin
  apiGroup: rbac.authorization.k8s.io
---
apiVersion: v1
items:
- apiVersion: tekton.dev/v1alpha1
  kind: PipelineResource
  metadata:
    name: input
  spec:
    type: git
    params:
    - name: resource0
      value: http://github.com/foo/archive.tar.gz
kind: List
---
apiVersion: tekton.dev/v1alpha1
kind: Pipeline
metadata:
  name: l-txt-pipeline
spec:
  resources:
  - name: input
    type: git
  tasks:
  - name: l-txt
    taskRef:
      name: l-txt-task
      kind: ""
    resources:
      inputs:
      - name: input
        resource: input
---
apiVersion: tekton.dev/v1alpha1
kind: Task
metadata:
  name: l-txt-task
spec:
  inputs:
    resources:
    - name: input
      type: git
  outputs: {}
  steps:
  - name: targz
    image: ubuntu
    env:
    - name: foo
      value: bar
    command:
    - /bin/bash
    args:
    - -c
    - tar xzvf http://github.com/foo/archive.tar.gz
    - -c
    - cat source/file.txt
---
apiVersion: tekton.dev/v1alpha1
kind: PipelineRun
metadata:
  name: l-txt-pipeline-run
spec:
  serviceAccount: core
  timeout: 1h0m0s
  pipelineRef:
    name: l-txt-pipeline
  trigger:
    type: manual
  resources:
  - name: input
    resourceref:
      name: input
---
```

Keeping as WIP, as there are real work to be done. Feel free to contribute, I have enabled `allow edits from maintainers` button.

cc @kvijai82 @stephenkinder @seabaylea @chilanti