### PR TITLE
Add condition to gate deployment on GitHub event types…

### DIFF
--- a/pipelines/experimental/container-scan-pipelines/container-scan-task.yaml
+++ b/pipelines/experimental/container-scan-pipelines/container-scan-task.yaml
@@ -25,7 +25,7 @@ spec:
         privileged: true
       image: <image_containing_scanner>
       command: ['/bin/bash']
-      args: ['-c', '${inputs.params.command-with-flags} ${inputs.resources.docker-image.url} ${inputs.params.scanner-arguments}']
+      args: ['-c', '$(inputs.params.command-with-flags) $(inputs.resources.docker-image.url) $(inputs.params.scanner-arguments)']
       volumeMounts:
         - name: docker-socket
           mountPath: /var/run/docker.sock

--- a/pipelines/incubator/build-deploy-pipeline.yaml
+++ b/pipelines/incubator/build-deploy-pipeline.yaml
@@ -4,29 +4,38 @@ kind: Pipeline
 metadata:
   name: CollectionId-build-deploy-pipeline
 spec:
+  params:
+  - name: event-headers
+    type: string
+    description: "The event headers"
   resources:
-    - name: git-source
-      type: git
-    - name: docker-image
-      type: image
+  - name: git-source
+    type: git
+  - name: docker-image
+    type: image
   tasks:
-    - name: build-task
-      taskRef:
-        name: CollectionId-build-task
-      resources:
-        inputs:
-        - name: git-source
-          resource: git-source
-        outputs:
-        - name: docker-image
-          resource: docker-image
-    - name: deploy-task
-      taskRef:
-        name: CollectionId-deploy-task
-      runAfter: [build-task]
-      resources:
-        inputs:
-        - name: git-source
-          resource: git-source
-        - name: docker-image
-          resource: docker-image
+  - name: build-task
+    taskRef:
+      name: CollectionId-build-task
+    resources:
+      inputs:
+      - name: git-source
+        resource: git-source
+      outputs:
+      - name: docker-image
+        resource: docker-image
+  - name: deploy-task
+    conditions:
+    - conditionRef: deployment-condition
+      params:
+      - name: event-headers
+        value: $(params.event-headers)
+    taskRef:
+      name: CollectionId-deploy-task
+    runAfter: [build-task]
+    resources:
+      inputs:
+      - name: git-source
+        resource: git-source
+      - name: docker-image
+        resource: docker-image

--- a/pipelines/incubator/build-task.yaml
+++ b/pipelines/incubator/build-task.yaml
@@ -6,65 +6,65 @@ metadata:
 spec:
   inputs:
     resources:
-      - name: git-source
-        type: git
+    - name: git-source
+      type: git
     params:
-      - name: pathToDockerFile
-        default: /workspace/extracted/Dockerfile
-      - name: pathToContext
-        default: /workspace/extracted
+    - name: pathToDockerFile
+      default: /workspace/extracted/Dockerfile
+    - name: pathToContext
+      default: /workspace/extracted
   outputs:
     resources:
-      - name: docker-image
-        type: image
+    - name: docker-image
+      type: image
   steps:
-    - name: assemble-extract
-      securityContext:
-        privileged: true
-      image: appsody/appsody-buildah
-      command: ["/bin/bash"]
-      args:
-        - -c
-        - "/extract.sh"
-      env:
-        - name: gitsource
-          value: git-source
-      volumeMounts:
-        - mountPath: /var/lib/containers
-          name: varlibcontainers
-    - name: validate-collection-is-active
-      securityContext:
-        privileged: true
-      image: kabanero/validate-collection
-      command: ["/bin/bash"]
-      args:
-        - -c
-        - "/validate.sh"
-      env:
-        - name: gitsource
-          value: git-source
-    - name: build-bud
-      securityContext:
-        privileged: true
-      image: appsody/appsody-buildah
-      command: ['buildah', 'bud', '--tls-verify=false', '--format=docker', '-f', '${inputs.params.pathToDockerFile}', '-t', '${outputs.resources.docker-image.url}', '${inputs.params.pathToContext}']
-      env:
-        - name: gitsource
-          value: git-source
-      volumeMounts:
-        - mountPath: /var/lib/containers
-          name: varlibcontainers
-    - name: build-push
-      securityContext:
-        privileged: true
-      image: appsody/appsody-buildah
-      command: ['buildah', 'push', '--tls-verify=false', '${outputs.resources.docker-image.url}', 'docker://${outputs.resources.docker-image.url}']
-      env:
-        - name: gitsource
-          value: git-source
-      volumeMounts:
-        - mountPath: /var/lib/containers
-          name: varlibcontainers
+  - name: assemble-extract
+    securityContext:
+      privileged: true
+    image: appsody/appsody-buildah
+    command: ["/bin/bash"]
+    args:
+    - -c
+    - "/extract.sh"
+    env:
+    - name: gitsource
+      value: git-source
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+  - name: validate-collection-is-active
+    securityContext:
+      privileged: true
+    image: kabanero/validate-collection
+    command: ["/bin/bash"]
+    args:
+    - -c
+    - "/validate.sh"
+    env:
+    - name: gitsource
+      value: git-source
+  - name: build-bud
+    securityContext:
+      privileged: true
+    image: appsody/appsody-buildah
+    command: ['buildah', 'bud', '--tls-verify=false', '--format=docker', '-f', '$(inputs.params.pathToDockerFile)', '-t', '$(outputs.resources.docker-image.url)', '$(inputs.params.pathToContext)']
+    env:
+    - name: gitsource
+      value: git-source
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+  - name: build-push
+    securityContext:
+      privileged: true
+    image: appsody/appsody-buildah
+    command: ['buildah', 'push', '--tls-verify=false', '$(outputs.resources.docker-image.url)', 'docker://$(outputs.resources.docker-image.url)']
+    env:
+    - name: gitsource
+      value: git-source
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
   volumes:
-    - name: varlibcontainers
-      emptyDir: {}
+  - name: varlibcontainers
+    emptyDir: {}

--- a/pipelines/incubator/deploy-task.yaml
+++ b/pipelines/incubator/deploy-task.yaml
@@ -6,42 +6,42 @@ metadata:
 spec:
   inputs:
     resources:
-      - name: git-source
-        type: git
-      - name: docker-image
-        type: image
+    - name: git-source
+      type: git
+    - name: docker-image
+      type: image
     params:
-      - name: repository-name
-        default: CollectionId
-      - name: app-deploy-file-name
-        default: app-deploy.yaml
+    - name: repository-name
+      default: CollectionId
+    - name: app-deploy-file-name
+      default: app-deploy.yaml
   steps:
-    - name: modify-app-deploy-yaml
-      image: registry.access.redhat.com/ubi8/ubi:latest
-      command: ['/bin/bash']
-      args:
-        - -cex
-        - |
-          echo "Checking for app-deploy.yaml"
-          APP_DEPLOY_YAML=$(find /workspace/git-source -name ${YAMLFILE} -type f)
-          if [ -z "$APP_DEPLOY_YAML" ]; then
-            echo "ERROR: app-deploy.yaml not found in project.  Please run appsody deploy --generate-only in your appsody project to generate the app-deploy.yaml and check it into your repo before running the pipeline."
-            exit 1
-          fi
-          # Replace the image name
-          echo "Replacing image name in app-deploy.yaml ${IMG}"
-          sed -i -e 's#applicationImage: .*$#applicationImage: '"$IMG"'#g' ${APP_DEPLOY_YAML}
-      env:
-        - name: REPO
-          value: ${inputs.params.repository-name}
-        - name: IMG
-          value: ${inputs.resources.docker-image.url}
-        - name: YAMLFILE
-          value: ${inputs.params.app-deploy-file-name}
-    - name: deploy-image
-      image: lachlanevenson/k8s-kubectl
-      command: ['/bin/sh']
-      args: ['-c', 'find /workspace/git-source -name ${YAMLFILE} -type f|xargs kubectl apply -f']
-      env:
-        - name: YAMLFILE
-          value: ${inputs.params.app-deploy-file-name}
+  - name: modify-app-deploy-yaml
+    image: registry.access.redhat.com/ubi8/ubi:latest
+    command: ['/bin/bash']
+    args:
+    - -cex
+    - |
+      echo "Checking for app-deploy.yaml"
+      APP_DEPLOY_YAML=$(find /workspace/git-source -name ${YAMLFILE} -type f)
+      if [ -z "$APP_DEPLOY_YAML" ]; then
+        echo "ERROR: app-deploy.yaml not found in project.  Please run appsody deploy --generate-only in your appsody project to generate the app-deploy.yaml and check it into your repo before running the pipeline."
+        exit 1
+      fi
+      # Replace the image name
+      echo "Replacing image name in app-deploy.yaml ${IMG}"
+      sed -i -e 's#applicationImage: .*$#applicationImage: '"$IMG"'#g' ${APP_DEPLOY_YAML}
+    env:
+    - name: REPO
+      value: $(inputs.params.repository-name)
+    - name: IMG
+      value: $(inputs.resources.docker-image.url)
+    - name: YAMLFILE
+      value: $(inputs.params.app-deploy-file-name)
+  - name: deploy-image
+    image: lachlanevenson/k8s-kubectl
+    command: ['/bin/sh']
+    args: ['-c', 'find /workspace/git-source -name ${YAMLFILE} -type f|xargs kubectl apply -f']
+    env:
+    - name: YAMLFILE
+      value: $(inputs.params.app-deploy-file-name)

--- a/pipelines/incubator/deployment-condition.yaml
+++ b/pipelines/incubator/deployment-condition.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Condition
+metadata:
+  name: deployment-condition
+spec:
+  params:
+  - name: event-headers
+    type: string
+    description: "The GitHub event headers"
+  check:
+    name: deployment-condition
+    image: stedolan/jq
+    command:
+    - bash
+    args:
+    - -ce
+    - |
+      [[ $(jq '."Ce-Github-Event"[0]' <<< '$(params.event-headers)') = *"push"* ]]


### PR DESCRIPTION
# Changes
Add condition to gate deployment on GitHub event type
Update yaml formatting to be consistent
Update interpolation since `${}` is deprecated with Tekton 0.7

## Additional Info
The Tekton Dashboard webhooks will now pass an `event-headers` param into `PipelineRuns` once https://github.com/tektoncd/experimental/pull/264 is merged to make this deployment condition possible.

The names of Tekton `Condition` maintains the `ContainerId` prefix, which is not a valid Kubernetes name, but should be replace as specified by https://github.com/kabanero-io/kabanero-operator/pull/161
